### PR TITLE
Fix scrolling to a local fragment

### DIFF
--- a/css/index.less
+++ b/css/index.less
@@ -189,8 +189,19 @@ footer {
     }
 }
 
-:target::before {
-    height: @navbar-height;
+html {
+    /* avoid overlapping with fixed header when scrolling to a local fragment */ 
+    scroll-padding-top: 6em;
+    overflow-y: auto;
+}
+div#body > a[name] {
+    display: block; width: 100%; /* to apply decoration */
+    :target {
+        scroll-margin-top: 5ex; /* the space for above title */
+    }
+}
+:target {
+    border-bottom: 0.2em gray dotted;
 }
 
 /* sidenav + toggle button */


### PR DESCRIPTION
Problem: on navigation to a local fragment, the web-page is scrolled, and the fixed web-page header overlaps the title of the fragment.
Solution: use the css property 'scroll-padding-top' in 'html' element (that is the main document scroller) to reserve space for the header.  Reserve additional space when an element 'a' is the target, since it's placed after the actual fragment title. Remove the old solution (see commit#42c301bc) that doesn't work.
Bounce: decorate the target element with bottom dotted line to make it more visible.

Fixes Issue#13