### PR TITLE
Fix scrolling to a local fragment, tune

### DIFF
--- a/css/index.less
+++ b/css/index.less
@@ -194,13 +194,15 @@ html {
     scroll-padding-top: 6em;
     overflow-y: auto;
 }
-div#body > a[name] {
-    display: block; width: 100%; /* to apply decoration */
-    :target {
+div#body {
+    > a[name] {
+        display: block; /* to apply a decoration even if the element is empty */
+    }
+    > a[name]:target {
         scroll-margin-top: 5ex; /* the space for above title */
     }
 }
-:target {
+:target:not(div):not(section) {
     border-bottom: 0.2em gray dotted;
 }
 


### PR DESCRIPTION
Due to a mistake in a LESS code fragment, a generated CSS selector is: `a[name] :target` (i.e. a descendant of `a[name]` that is a target), but we need `a[name]:target` (i.e. `a[name]` that is a target).

Also, don't apply dotted bottom border to a target element when it is a `div` or `section` element, since usually they envelope both the title and body of a fragment. But we want to decorate only a title (if any).