### PR TITLE
FIX site.js -- allow correct tags in Markdown

### DIFF
--- a/site.js
+++ b/site.js
@@ -70,7 +70,7 @@ module.exports = {
 
         function saneMarked( text ) {
             text = text.replace( /<br\/?>/g, '  \n' );
-            text = text.replace( /<([A-Za-z]+[-a-zA-Z0-9 ]*)>/g, '< $1 >' );
+            text = text.replace( /<([^/\s][^>/]+?)>(?!.*?<\/\1>)/g, '&lt;$1&gt;' );
             return cleanHTML( marked( text ) );
         }
 


### PR DESCRIPTION
The `marked` module (which converts Markdown into HTML) does not escape `<`, if it looks like the start of an HTML tag. So, a wrong tag soup can appear in the result.

In the same time, correct HTML tags were used sometimes, e.g. `<ins> ... </ins>`.

To distinguish correct tags from other use of `<`, the new regexp does lookahead  assertion for the closing tag.

If `<` and `>` are used not for a correct tag, they are just escaped via `&lt;` and `&gt;`, to avoid an incorrect tag soup in the result.